### PR TITLE
Add shared CSS and clean up inline styles

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,14 +9,15 @@ import db
 app = Dash(__name__, use_pages=True, suppress_callback_exceptions=True)
 
 app.layout = dmc.MantineProvider(
+    theme={"colorScheme": "light", "primaryColor": "blue", "fontFamily": "Arial, sans-serif"},
     children=[
         html.H1("Multi-Page Timeline Application"),
-        html.Div([
-            dcc.Link(page["name"], href=page["relative_path"], style={"margin": "10px"})
-            for page in dash.page_registry.values()
-        ]),
-        dash.page_container
-    ]
+        html.Div(
+            [dcc.Link(page["name"], href=page["relative_path"], className="nav-link")
+             for page in dash.page_registry.values()],
+        ),
+        dash.page_container,
+    ],
 )
 
 if __name__ == "__main__":

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,0 +1,95 @@
+/* Application wide styles */
+
+body {
+    font-family: Arial, sans-serif;
+    background: #f5f5f5;
+    margin: 0;
+    padding: 0;
+}
+
+h1, h2 {
+    color: #333;
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.page-container {
+    margin: 0 auto;
+    max-width: 1000px;
+    padding: 20px;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.form-group {
+    margin-bottom: 10px;
+}
+
+.full-width {
+    width: 100%;
+}
+
+.textarea {
+    width: 100%;
+    height: 80px;
+}
+
+.message {
+    margin-top: 10px;
+    color: red;
+}
+
+button {
+    background-color: #1971c2;
+    color: #fff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button.delete {
+    background-color: #c23;
+}
+
+.filter-controls {
+    margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+}
+.filter-controls label {
+    margin-right: 8px;
+}
+.filter-spacing {
+    margin-left: 20px;
+    margin-right: 8px;
+}
+.nav-link {
+    margin: 0 10px;
+}
+
+.flex-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 10px;
+}
+
+.flex-1 {
+    flex: 1;
+}
+
+.ml-20 {
+    margin-left: 20px;
+}
+
+.checklist {
+    display: inline-block;
+    margin-left: 10px;
+}
+
+
+
+
+

--- a/src/pages/add_event.py
+++ b/src/pages/add_event.py
@@ -15,51 +15,54 @@ def layout():
         html.H2("Add New Event"),
         html.Div([
             html.Label("Category:*"),
-            dcc.Input(id="input-category", type="text", placeholder="e.g. Politics", style={"width": "100%"})
-        ], style={"marginBottom": "10px"}),
+            dcc.Input(id="input-category", type="text", placeholder="e.g. Politics", className="full-width")
+        ], className="form-group"),
         html.Div([
             html.Label("Topic:*"),
-            dcc.Input(id="input-topic", type="text", placeholder="e.g. War", style={"width": "100%"})
-        ], style={"marginBottom": "10px"}),
+            dcc.Input(id="input-topic", type="text", placeholder="e.g. War", className="full-width")
+        ], className="form-group"),
         html.Div([
             html.Label("Name:*"),
-            dcc.Input(id="input-name", type="text", placeholder="e.g. World War III", style={"width": "100%"})
-        ], style={"marginBottom": "10px"}),
+            dcc.Input(id="input-name", type="text", placeholder="e.g. World War III", className="full-width")
+        ], className="form-group"),
         html.Div([
             html.Label("Country:"),
-            dcc.Input(id="input-country", type="text", placeholder="e.g. USA", style={"width": "100%"})
-        ], style={"marginBottom": "10px"}),
+            dcc.Input(id="input-country", type="text", placeholder="e.g. USA", className="full-width")
+        ], className="form-group"),
         html.Div([
             html.Label("Start Date:*"),
             dcc.DatePickerSingle(id="input-date-start", display_format="YYYY-MM-DD")
-        ], style={"marginBottom": "10px"}),
+        ], className="form-group"),
         html.Div([
             html.Label("End Date:"),
             dcc.DatePickerSingle(id="input-date-end", display_format="YYYY-MM-DD")
-        ], style={"marginBottom": "10px"}),
+        ], className="form-group"),
         html.Div([
             html.Label("Description:"),
             html.Br(),
-            dcc.Textarea(id="input-description", placeholder="Event description (optional)",
-                         style={"width": "100%", "height": "80px"})
-        ], style={"marginBottom": "10px"}),
+            dcc.Textarea(
+                id="input-description",
+                placeholder="Event description (optional)",
+                className="textarea",
+            ),
+        ], className="form-group"),
         html.Div([
             html.Label("Affected By (select events that cause this event):"),
             dcc.Dropdown(id="input-affected-by", options=cast(Any, event_options),multi=True,
                          placeholder="Select preceding related events")
-        ], style={"marginBottom": "10px"}),
+        ], className="form-group"),
         html.Div([
             html.Label("Affects (select events that this event will cause):"),
             dcc.Dropdown(id="input-affects", options=cast(Any, event_options), multi=True,
                          placeholder="Select subsequent related events")
-        ], style={"marginBottom": "20px"}),
+        ], className="form-group"),
         # Submit button
         html.Button("Add Event", id="submit-event", n_clicks=0),
         # Hidden location component for redirecting after submission
         dcc.Location(id="redirect-page", href="", refresh=False),
         # Message area for errors or confirmations
-        html.Div(id="form-message", style={"color": "red", "marginTop": "10px"})
-    ])
+        html.Div(id="form-message", className="message")
+    ], className="page-container")
 
 @callback(
     Output("redirect-page", "href"),

--- a/src/pages/edit_event.py
+++ b/src/pages/edit_event.py
@@ -16,13 +16,13 @@ def layout():
     ]
     return html.Div([
         html.H2("Edit / Delete Existing Event"),
-        dcc.Dropdown(id="event-picker", options = cast(Any, event_options),
-                     placeholder="Select an event to edit"),
+        dcc.Dropdown(id="event-picker", options=cast(Any, event_options),
+                     placeholder="Select an event to edit", className="full-width"),
         html.Br(),
         html.Div(id="edit-form-container"),      # populated once an event is chosen
         dcc.Location(id="go-back", href="", refresh=False),
-        html.Div(id="edit-msg", style={"marginTop": "10px", "color": "red"})
-    ], style={"marginLeft": "40px", "marginRight": "40px", "maxWidth": "1200px"})
+        html.Div(id="edit-msg", className="message")
+    ], className="page-container")
 
 # --- populate the form when an event is picked ------------------------------
 @callback(Output("edit-form-container", "children"),
@@ -37,11 +37,11 @@ def load_event_form(selected_id):
     topics = events_all_df["topic"].unique().tolist()
     countries = events_all_df["country"].unique().tolist()
     return html.Div([
-        html.Label("Name:"),  dcc.Input(id="e-name", value=ev["name"], style={"width": "100%"}),
+        html.Label("Name:"),  dcc.Input(id="e-name", value=ev["name"], className="full-width"),
         html.Br(),
         html.Label("Description:"),
         dcc.Textarea(id="e-desc", value=ev["description"] or "",
-                     style={"width": "100%", "height": "80px"}),
+                     className="textarea"),
         html.Br(),
         html.Label("Start Date:"), dcc.DatePickerSingle(id="e-start", date=ev["date_start"]),
         html.Label("End Date:"),  dcc.DatePickerSingle(id="e-end",   date=ev["date_end"]),
@@ -59,7 +59,7 @@ def load_event_form(selected_id):
                         clearable=True,
                         maxTags=1,
                     ),
-                ], style={"flex": 1}),
+                ], className="flex-1"),
 
                 html.Div([
                     html.Label("Topic:"),
@@ -71,7 +71,7 @@ def load_event_form(selected_id):
                         clearable=True,
                         maxTags=1,
                         ),
-                ], style={"flex": 1}),
+                ], className="flex-1"),
 
                 html.Div([
                     html.Label("Country:"),
@@ -83,14 +83,9 @@ def load_event_form(selected_id):
                         clearable=True,
                         maxTags=1,
                         ),
-                ], style={"flex": 1}),
+                ], className="flex-1"),
             ],
-            style={
-                "display": "flex",
-                "gap": "12px",
-                "alignItems": "flex-end",
-                "marginBottom": "10px",
-            },
+            className="flex-row",
         ),
         html.Div(
             [
@@ -102,9 +97,9 @@ def load_event_form(selected_id):
                         value=ev["affected_by"],
                         multi=True,
                         placeholder="Select events that caused this event",
-                        style={"width": "100%"},
+                        className="full-width",
                     ),
-                ], style={"flex": 1}),
+                ], className="flex-1"),
 
                 html.Div([
                     html.Label("Affects:"),
@@ -114,20 +109,15 @@ def load_event_form(selected_id):
                         value=ev["affects"],
                         multi=True,
                         placeholder="Select events that this event caused",
-                        style={"width": "100%"},
+                        className="full-width",
                     ),
-                ], style={"flex": 1}),
+                ], className="flex-1"),
             ],
-            style={
-                "display": "flex",
-                "gap": "12px",
-                "marginBottom": "10px",
-            },
+            className="flex-row",
         ),
         html.Br(), html.Br(),
         html.Button("Save Changes", id="save-btn", n_clicks=0),
-        html.Button("Delete", id="del-btn", n_clicks=0,
-                    style={"marginLeft": "20px", "background": "#c23", "color": "white"}),
+        html.Button("Delete", id="del-btn", n_clicks=0, className="delete ml-20"),
     ])
 
 # --- handle save / delete ----------------------------------------------------

--- a/src/pages/timeline.py
+++ b/src/pages/timeline.py
@@ -126,21 +126,21 @@ def layout():
         html.H2("Timeline View"),
         # Filter controls section
         html.Div([
-            html.Label("Category:", style={"margin-right": "8px"}),
+            html.Label("Category:"),
             dcc.Dropdown(
             id="filter-category",
             options=[{"label": cat, "value": cat} for cat in categories],
             value=categories,  # default select all categories
             multi=True
         ),
-        html.Label(" Country:", style={"margin-left": "20px", "margin-right": "8px"}),
+        html.Label(" Country:", className="filter-spacing"),
         dcc.Dropdown(
             id="filter-country",
             options=[{"label": c, "value": c} for c in countries],
             value=countries,  # default select all countries
             multi=True
         ),
-        html.Label(" Date Range:", style={"margin-left": "20px", "margin-right": "8px"}),
+        html.Label(" Date Range:", className="filter-spacing"),
         dcc.DatePickerRange(
             id="filter-date",
             start_date=min_date,
@@ -149,17 +149,17 @@ def layout():
             max_date_allowed=max_date,
             display_format="YYYY-MM-DD"
         ),
-        html.Label(" ", style={"margin-left": "20px"}),  # spacer
+        html.Label(" ", className="filter-spacing"),  # spacer
         dcc.Checklist(
             id="toggle-arrows",
             options=[{"label": "Show causal links", "value": "show"}],
             value=[],  # unchecked by default (no arrows)
-            style={"display": "inline-block", "margin-left": "10px"}
+            className="checklist"
         )
-    ], style={"marginBottom": "20px", "display": "flex", "flexWrap": "wrap", "alignItems": "center"}),
+    ], className="filter-controls"),
     # Timeline graph component
     dcc.Graph(id="timeline-graph", figure=initial_fig)
-])
+], className="page-container")
 
 # Callback to update the timeline graph when filters or arrow toggle change
 @callback(


### PR DESCRIPTION
## Summary
- provide a global stylesheet under `src/assets`
- theme MantineProvider and use CSS classes instead of inline styles
- refactor Add/Edit pages and the timeline view to use shared classes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b3122e94832e87973dd755b170d6