### PR TITLE
Add database operation tests and improve cleanup

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -25,3 +25,26 @@ def test_insert_event_unique():
     else:
         assert False, 'duplicate tag did not raise'
     os.unlink(path)
+
+def test_update_event_fields():
+    path = setup_temp_db()
+    db.insert_event('Cat','Topic','First','Country','2000-01-01',None,'','tag1','','')
+    db.insert_event('Cat','Topic','Second','Country','2000-01-02',None,'','tag2','','')
+    ev = db.get_event_by_tag('tag1')
+    db.update_event(ev['id'], name='Updated', affects='tag2')
+    updated = db.get_event_by_tag('tag1')
+    assert updated['name'] == 'Updated'
+    assert updated['affects'] == 'tag2'
+    os.unlink(path)
+
+
+def test_delete_event_removes_relationships():
+    path = setup_temp_db()
+    db.insert_event('Cat','Topic','First','Country','2000-01-01',None,'','tag1','','tag2')
+    db.insert_event('Cat','Topic','Second','Country','2000-01-02',None,'','tag2','tag1','')
+    e1 = db.get_event_by_tag('tag1')
+    db.delete_event(e1['id'])
+    assert db.get_event_by_tag('tag1') is None
+    e2 = db.get_event_by_tag('tag2')
+    assert 'tag1' not in (e2['affected_by'] or '')
+    os.unlink(path)


### PR DESCRIPTION
## Summary
- ensure database deletion removes references
- cover update_event and delete_event functions with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b31272ac832ea3b87766915bea21