### PR TITLE
Center country flags on timeline

### DIFF
--- a/src/flags.py
+++ b/src/flags.py
@@ -1,0 +1,19 @@
+FLAG_EMOJIS = {
+    "USA": "🇺🇸",
+    "Germany": "🇩🇪",
+    "Israel": "🇮🇱",
+    "China": "🇨🇳",
+    "Russia": "🇷🇺",
+    "Denmark": "🇩🇰",
+    "United Kingdom": "🇬🇧",
+    "France": "🇫🇷",
+    "Canada": "🇨🇦",
+    "Japan": "🇯🇵",
+    "India": "🇮🇳",
+    "Global": "🌐",
+}
+
+
+def get_flag(country: str) -> str:
+    """Return the emoji flag for a given country name."""
+    return FLAG_EMOJIS.get(country, "")

--- a/src/pages/timeline.py
+++ b/src/pages/timeline.py
@@ -3,6 +3,7 @@ from dash import html, dcc, callback, Input, Output, State
 import plotly.express as px
 import plotly.graph_objects as go
 from datetime import datetime
+from flags import get_flag
 import dash_mantine_components as dmc 
 import db
 # 4) add one scatter trace per category for instant events
@@ -62,19 +63,22 @@ def make_timeline_figure(events, show_arrows=False):
         style = line_styles.get(tr.name, "solid")
         tr.update(line=dict(dash=style))
 
-    # Add small flag annotations based on country
-    flag_emojis = {"USA": "🇺🇸", "Germany": "🇩🇪", "Global": "🌐"}
+    # Add small flag annotations centered on each event bar
+    def mid_point(start: str, end: str | None) -> datetime:
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end) if end else start_dt
+        return start_dt + (end_dt - start_dt) / 2
+
     for ev in events_sorted:
-        flag = flag_emojis.get(ev["country"], "")
+        flag = get_flag(ev["country"])
         if flag:
             fig.add_annotation(
-                x=ev["date_start"],
+                x=mid_point(ev["date_start"], ev["date_end"]),
                 y=ev["tag"],
                 text=flag,
                 showarrow=False,
-                xanchor="right",
+                xanchor="center",
                 yanchor="middle",
-                xshift=-8,
             )
     points = [e for e in events if not e["date_end"]]
     # 3) grab the colour that Plotly just used for every category


### PR DESCRIPTION
## Summary
- centralize flag mappings in `flags.py`
- load emoji flags from `get_flag()` helper
- compute midpoints so country flags appear centered on each bar
- expand supported country flags

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875a74857c832eab591c0980b2eaa9